### PR TITLE
transfer CRAB/CMSSW lumi mask; use subdirectories

### DIFF
--- a/SUSYAnalysis/cfg/crab_with_das/heppy_crab_config_env.py
+++ b/SUSYAnalysis/cfg/crab_with_das/heppy_crab_config_env.py
@@ -21,8 +21,8 @@ print "sample = ",sample
 ##
 ## try to identify data
 ##
-#if m.group(2).startswith("Run201"):
-#  config.Data.splitting = "LumiBased"
+if m.group(2).startswith("Run201"):
+  config.Data.splitting = "LumiBased"
 
 #NJOBS=int(os.environ["NJOBS"])
 production_label = os.environ["CMG_PROD_LABEL"]


### PR DESCRIPTION
Two changes:
- copy CMSSW lumi mask set by crab (extracted from process.source.lumisToProcess) to a JSON to be read by cmg
- enable subdirectories in cmg output
